### PR TITLE
documentation/basic-ad-update

### DIFF
--- a/.github/workflows/add-2nd-reviewer.yml
+++ b/.github/workflows/add-2nd-reviewer.yml
@@ -6,5 +6,5 @@ on:
 jobs:
   auto_assign_reviewer:
     if: github.event.review.state == 'approved'
-    uses: fivetran/dbt_package_automations/.github/workflows/add-2nd-reviewer.yml
+    uses: fivetran/dbt_package_automations/.github/workflows/add-2nd-reviewer.yml@main
     secrets: inherit

--- a/.github/workflows/add-2nd-reviewer.yml
+++ b/.github/workflows/add-2nd-reviewer.yml
@@ -1,0 +1,10 @@
+name: '2nd reviewer'
+on:
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  auto_assign_reviewer:
+    if: github.event.review.state == 'approved'
+    uses: fivetran/dbt_package_automations/.github/workflows/add-2nd-reviewer.yml
+    secrets: inherit

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -9,5 +9,5 @@ on:
 jobs:
   call-workflow-passing-data:
     if: github.event.pull_request.merged
-    uses: fivetran/dbt_package_automations/.github/workflows/auto-release.yml
+    uses: fivetran/dbt_package_automations/.github/workflows/auto-release.yml@main
     secrets: inherit

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,13 @@
+name: 'auto release'
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
+
+jobs:
+  call-workflow-passing-data:
+    if: github.event.pull_request.merged
+    uses: fivetran/dbt_package_automations/.github/workflows/auto-release.yml
+    secrets: inherit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 [PR #36](https://github.com/fivetran/dbt_facebook_ads/pull/36) includes the following updates:
 ## Documentation Updates
-- The prerequisite steps for generating the `basic_ad` pre-built report have been modified to reflect the current state of the Facebook Ads connector.
+- The [prerequisite steps in the README](https://github.com/fivetran/dbt_facebook_ads#step-1-prerequisites) for generating the `basic_ad` pre-built report have been modified to reflect the current state of the Facebook Ads connector.
 - Adds the [DECISIONLOG](DECISIONLOG.md) to clarify why there exist differences among aggregations across different grains.
 
 # dbt_facebook_ads v0.7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# dbt_facebook_ads_source v0.7.1
+
+[PR #31](https://github.com/fivetran/dbt_facebook_ads_source/pull/31) includes the following updates:
+## Documentation Updates
+- The prerequisite steps for generating the `basic_ad` pre-built report have been modified to reflect the current state of the Facebook Ads connector.
+- Adds the [DECISIONLOG](DECISIONLOG.md) to clarify why there exist differences among aggregations across different grains.
+
 # dbt_facebook_ads v0.7.0
 [PR #34](https://github.com/fivetran/dbt_facebook_ads/pull/34) includes the following updates:
 ## Feature update 🎉

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-# dbt_facebook_ads_source v0.7.1
+# dbt_facebook_ads v0.7.1
 
-[PR #31](https://github.com/fivetran/dbt_facebook_ads_source/pull/31) includes the following updates:
+[PR #36](https://github.com/fivetran/dbt_facebook_ads/pull/36) includes the following updates:
 ## Documentation Updates
 - The prerequisite steps for generating the `basic_ad` pre-built report have been modified to reflect the current state of the Facebook Ads connector.
 - Adds the [DECISIONLOG](DECISIONLOG.md) to clarify why there exist differences among aggregations across different grains.

--- a/DECISIONLOG.md
+++ b/DECISIONLOG.md
@@ -16,3 +16,8 @@ For source history tables that provide a `updated_at` field, the most recent rec
 
 ## Passing Through Metrics Not Available 
 Please note that additional pass through metrics are only available for the source models as additional metrics such as `cpc`, `cpm` and `ctr` are already aggregated metrics that should not be rolled up into higher levels of reporting.
+
+## Why don't metrics add up across different grains (Ex. ad level vs campaign level)?
+Not all ads are served at the ad level. In other words, there are some ads that are served only at the ad group, campaign, etc. levels. The implications are that since not ads are included in the ad-level report, their associated spend, for example, won't be included at that grain. Therefore your spend totals may differ across the ad grain and another grain. 
+
+This is a reason why we have broken out the ad reporting packages into separate hierarchical end models (Ad, Ad Group, Campaign, and more). Because if we only used ad-level reports, we could be missing data.

--- a/README.md
+++ b/README.md
@@ -41,14 +41,10 @@ To use this dbt package, you must have the following:
 
 - At least one Fivetran Facebook Ads connector syncing data into your destination.
 - A **BigQuery**, **Snowflake**, **Redshift**, **PostgreSQL**, or **Databricks** destination.
-- You will need to configure your Facebook Ads connector to pull the `BASIC_AD` pre-built report. Follow the below steps in the Fivetran UI to do so:
-    1. Navigate to the connector setup form (**Setup** -> **Edit connection details** for pre-existing connectors)
-    2. Click **Add table** 
-    3. Select **Pre-built Report**
-    4. Set the table name to `basic_ad`
-    5. Select `BASIC_AD` as the corresponding pre-built report
-    6. Select a daily aggregation period
-    7. Click **Ok** and **Save & test**!
+- You will need to configure your Facebook Ads connector to pull the `basic_ad` pre-built report. This pre-built report should be enabled in your connector by default. However, to confirm this pre-built report is actively syncing you may perform the following steps:
+    1. Navigate to the connector schema tab.
+    2. Search for `basic_ad` and confirm it is selected.
+    3. If not selected, do so and sync. If already selected you are ready to run the models!
 
 ### Databricks Dispatch Configuration
 If you are using a Databricks destination with this package you will need to add the below (or a variation of the below) dispatch configuration within your `dbt_project.yml`. This is required in order for the package to accurately search for macros within the `dbt-labs/spark_utils` then the `dbt-labs/dbt_utils` packages respectively.

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'facebook_ads'
-version: '0.7.0'
+version: '0.7.1'
 config-version: 2
 require-dbt-version: [">=1.3.0", "<2.0.0"]
 models:

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'facebook_ads_integration_tests'
-version: '0.7.0'
+version: '0.7.1'
 profile: 'integration_tests'
 config-version: 2
 

--- a/integration_tests/requirements.txt
+++ b/integration_tests/requirements.txt
@@ -4,6 +4,4 @@ dbt-redshift>=1.3.0,<2.0.0
 dbt-postgres>=1.3.0,<2.0.0
 dbt-spark>=1.3.0,<2.0.0
 dbt-spark[PyHive]>=1.3.0,<2.0.0
-dbt-databricks>=1.3.0,<2.0.0
-
-oscrypto @ git+https://github.com/wbond/oscrypto.git@d5f3437
+dbt-databricks>=1.6.0,<2.0.0


### PR DESCRIPTION
## PR Overview
**This PR will address the following Issue/Feature:** #35 and #32 

**This PR will result in the following new package version:** `v0.7.1`
<!--- Please add details around your decision for breaking vs non-breaking version upgrade. If this is a breaking change, were backwards-compatible options explored? -->

This will not be a breaking change as this only updates documentation.

## Remaining PR components
Please see the accompanying [source PR](https://github.com/fivetran/dbt_facebook_ads_source/pull/31) which contains all the same information.