### PR TITLE
Fix typo that called the `facebook_ads__url_report` the `*_utm_report`

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The following table provides a detailed list of all tables materialized within t
 | [facebook_ads__campaign_report](https://fivetran.github.io/dbt_facebook_ads/#!/model/model.facebook_ads.facebook_ads__campaign_report)            | Each record in this table represents the daily performance of a campaign at the campaign/advertising_channel/advertising_channel_subtype level. |
 | [facebook_ads__ad_set_report](https://fivetran.github.io/dbt_facebook_ads/#!/model/model.facebook_ads.facebook_ads__ad_set_report)            | Each record in this table represents the daily performance at the ad set level. |
 | [facebook_ads__ad_report](https://fivetran.github.io/dbt_facebook_ads/#!/model/model.facebook_ads.facebook_ads__ad_report)            | Each record in this table represents the daily performance at the ad level. |
-| [facebook_ads__utm_report](https://fivetran.github.io/dbt_facebook_ads/#!/model/model.facebook_ads.facebook_ads__utm_report)            | Each record in this table represents the daily performance of URLs at the ad level. |
+| [facebook_ads__url_report](https://fivetran.github.io/dbt_facebook_ads/#!/model/model.facebook_ads.facebook_ads__url_report)            | Each record in this table represents the daily performance of URLs at the ad level. |
 <!--section-end-->
 
 ## How do I use the dbt package?


### PR DESCRIPTION
The URL report has the wrong name and a broken link the README 